### PR TITLE
Refactor commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "remslice"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "cli-clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remslice"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -128,11 +128,10 @@ rem_alias h al ffc
 ## Misc. Commands
 - `bye` - exit with a farewell message
 - `ping` - pong!
-- `wipe` - wipe the screen
+- `wipe`/`clear` - wipe the screen
 - `time` - display the current time
 - `copy`/`y` - copy ("yank") the last copyable message sent to the system clipboard (generally used after `score` or `time`)
 - `paste`/`p` - display the contents of the system clipboard
-- `pasterun!`/`pr!` - run the contents of the system clipboard as a command input to rem (dangerous--`paste` first to see contents!)
 
 ## Procedure/Action Commands
 - `score` - generate a daily score based on input prompts defined in your config
@@ -144,6 +143,7 @@ rem_alias h al ffc
 - `tda` - "todo append": add an entry into the todo file specified in `remrc.txt` (entries are automatically markdown bulleted with a dash)
 - `tdt` - "todo top": display the top (most recent) entries in the todo file (up until the most recent `##` header); display lowercase alphabetical IDs alongside each entry
 - `tdt2` - "todo top x2": display more of the top todo entries (up until the 2nd most recent `##` header)
+- `tdt {n}` - display even more of the top todo entries (up until the nth most recent `##` header)
 - `tdc` - "todo clear/complete": toggle the strikethrough for a todo in the todo file by its lowercase alphabetical ID (see `tdt`)
 - `tde` - "todo edit": edit the topmost todo entry by replacing it, used for making a correction
 - `tdae` - "todo append-edit": append text to the topmost todo entry, used for making a correction

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,128 @@
+use crate::remstate;
+use std::sync::LazyLock;
+
+pub enum CommandResult {
+    Nominal,
+    EndProgram
+}
+
+pub struct Command {
+    name: String,
+    min_args: i32,
+    /// The maximum number of arguments. If None, the min_args-th argument and beyond is one infinite string
+    max_args: Option<i32>,
+    pub run: fn(args: &Vec<String>, state: &mut remstate::RemState) -> CommandResult
+}
+
+impl Command {
+    pub fn matches(&self, name: &str, num_args: i32) -> bool {
+        return name == self.name
+            && num_args >= self.min_args
+            && (self.max_args.is_none() || num_args <= self.max_args.unwrap())
+    }
+
+    // Parse the input properly: return [Arg1, Arg2, "Infinite argument as one string"]
+    pub fn parse_input(&self, full_input: &str) -> Vec<String> {
+        let mut args_completed: i32 = -1;
+        let mut curr_str: String = String::new();
+        let mut res: Vec<String> = Vec::new();
+        for c in full_input.chars() {
+            let at_infinite_arg = args_completed >= self.min_args - 1;
+            if !at_infinite_arg && c == ' ' {
+                // Treat as a delimiting space before a new argument
+                if args_completed >= 0 {
+                    res.push(curr_str.clone());
+                }
+                curr_str.clear();
+                args_completed += 1;
+            } else {
+                // Treat as a verbatim input character
+                if at_infinite_arg {
+                    curr_str.push(c);
+                } else {
+                    let c_lower = c.to_lowercase().collect::<String>();
+                    curr_str.push_str(&c_lower);
+                }
+            }
+        }
+        if args_completed >= 0 {
+            res.push(curr_str);
+        }
+        for s in &res {
+            s.trim();
+        }
+        return res;
+    }
+}
+
+// Store these commands lazily so they are only accessed on the first call
+static COMMAND_LIST: LazyLock<Vec<Command>> = LazyLock::new(|| {vec![
+    Command {
+        name: String::from("ping"),
+        min_args: 0,
+        max_args: Some(0),
+        run: |args, state| {
+            // Do stuff
+            state.ping_count += 1;
+            println!("pong (x{})", state.ping_count);
+            println!("DBG: you entered {}", args.concat());
+            CommandResult::Nominal
+        }
+    },
+    Command {
+        name: String::from("q"),
+        min_args: 0,
+        max_args: Some(0),
+        run: |_args, _state| {
+            // Do stuff
+            println!("DBG: QUITTING");
+            CommandResult::EndProgram
+        }
+    },
+    Command {
+        name: String::from("tda"),
+        min_args: 1,
+        max_args: None,
+        run: |args, _state| {
+            // Do stuff
+            println!("DBG: you entered: {}", args[0]);
+            CommandResult::Nominal
+        }
+    },
+]});
+
+/// Return the number of space-separated arguments (not including the command name) and the command name
+fn process_input(full_input: &str) -> Option<(i32, String)> {
+    // TODO: impl myself to ignore spaces and keep case within quotes, handle backslashes, etc.
+    let splitted: Vec<&str> = full_input.split(' ').collect::<Vec<&str>>();
+    let mut res: Vec<String> = Vec::new();
+    for arg in splitted {
+        res.push(arg.trim().to_lowercase().to_string());
+    }
+    if res.len() == 0 {
+        return None;
+    }
+    Some(((res.len() as i32) - 1, res.first().unwrap().clone()))
+}
+
+/// Find the matching command based on the user's parsed input and run it
+pub fn run_command(full_input: &str, state: &mut remstate::RemState) -> Option<CommandResult> {
+    let processed = process_input(&full_input);
+    if processed.is_none() {
+        return None;
+    }
+    let (num_args, command_name) = processed.unwrap();
+    let found = COMMAND_LIST.iter().find(|&x| x.matches(&command_name, num_args));
+    match found {
+        Some(command) => {
+            // Run the command, parsing the input properly for the number of arguments
+            let parsed = command.parse_input(full_input);
+            let res = (command.run)(&parsed, state);
+            Some(res)
+        },
+        _ => {
+            // Try rem alias
+            None
+        }
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -17,13 +17,13 @@ enum ArgsLim {
     EndlessLastArg(i32),
     /// The number of arguments must be precisely this value
     Fixed(i32),
+    /// There must be no arguments
     None
-    // Idea: `Range(i32, i32)`: the number of arguments could fall between the minimum and maximum
 }
 
 struct Command {
     names: Vec<String>,
-    /// The maximum number of arguments. If None, the min_args-th argument and beyond is one infinite string
+    /// The number and structure of arguments that the command expects
     args_lim: ArgsLim,
     pub run: CommandRunFn
 }
@@ -37,6 +37,7 @@ impl Command {
         }
     }
 
+    /// Whether a user's inputted command matches this command's structure
     pub fn matches(&self, name: &str, num_args: i32) -> bool {
         self.names.iter().any(|s| s == name) && match self.args_lim {
             ArgsLim::EndlessLastArg(needed_args) => {
@@ -53,7 +54,7 @@ impl Command {
 
     /// Parse the input properly
     // Ex. "mycommand A B Endless arg as str" -> ["A", "B", "Endless argument as one string"]
-    /// This assumes that the command matches (and thus will not check argument counts)
+    /// This assumes that the command already matches (and thus will not check argument counts)
     pub fn parse_input(&self, full_input: &str) -> Vec<String> {
         // TODO: impl ignoring spaces and keeping case within quotes, handling backslashes, etc.
         match self.args_lim {
@@ -225,14 +226,14 @@ static COMMAND_LIST: LazyLock<Vec<Command>> = LazyLock::new(|| {vec![
         }
     ),
     Command::new(
-        string_vec!["tde"], ArgsLim::Fixed(1),
+        string_vec!["tde"], ArgsLim::EndlessLastArg(1),
         |args, state| {
             feature::run_tde(state, &args[0]);
             CommandResult::Nominal
         }
     ),
     Command::new(
-        string_vec!["tdae"], ArgsLim::Fixed(1),
+        string_vec!["tdae"], ArgsLim::EndlessLastArg(1),
         |args, state| {
             feature::run_tdae(state, &args[0]);
             CommandResult::Nominal
@@ -280,7 +281,7 @@ static COMMAND_LIST: LazyLock<Vec<Command>> = LazyLock::new(|| {vec![
     ),
     Command::new(
         string_vec!["paste", "p"], ArgsLim::None,
-        |_args, state| {
+        |_args, _state| {
             match utils::paste_from_clipboard() {
                 Some(contents) => {
                     println!("{}", contents);

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -1,8 +1,5 @@
 use crate::remstate;
-use crate::remdata;
 use crate::utils;
-use crate::config::Config;
-use crate::remfetch;
 use crate::command;
 
 pub fn run_score(state: &mut remstate::RemState) {
@@ -205,14 +202,10 @@ pub fn run_tde(state: &remstate::RemState, new_todo: &str) {
 
 /// Append-edit the latest todo
 pub fn run_tdae(state: &remstate::RemState, new_todo: &str) {
+    // If the first char is punctuation, don't include a space between the original and appended contents
     let formatted_to_append: String = match new_todo.chars().next().unwrap_or(' ') {
-        ',' | ';' | '-' | '.' => {
-            // Punctuation, so don't include a space between the original and appended contents
-            new_todo.to_string()
-        },
-        _ => {
-            format!(" {}", new_todo)
-        }
+        ',' | ';' | '-' | '.' | ':' => new_todo.to_string(),
+        _ => format!(" {}", new_todo)
     };
     if utils::edit_last_line_of_file(&state.config.get_todo_path(), &formatted_to_append, true) {
         println!("Appended to the topmost todo");

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -1,0 +1,86 @@
+use crate::remstate;
+use crate::remdata;
+use crate::utils;
+use crate::config::Config;
+use crate::remfetch;
+use crate::command;
+
+pub fn run_score(state: &mut remstate::RemState) {
+    // Get based on config
+    let divide_by: f32 = state.config.score_divby();
+    let formula_number: &str = &state.config.score_formula_number();
+    // Obtain relevant information
+    println!("Today's questions:");
+    let mut daily_score_disp = format!("Daily Score (Formula {}) = (", formula_number);
+    let mut total_score: f32 = 0.0;
+    for cat in state.config.score_positive() {
+        println!("{}", cat);
+        let uin = utils::get_user_input_decimal(0.0, 1.0);
+        total_score += uin;
+        daily_score_disp.push_str(&format!(" + {:.2}", uin));
+    }
+    for cat in state.config.score_negative() {
+        println!("{}", cat);
+        let uin = utils::get_user_input_decimal(0.0, 1.0);
+        total_score -= uin;
+        daily_score_disp.push_str(&format!(" - {:.2}", uin));
+    }
+    // Calculate and format
+    total_score /= divide_by;
+    daily_score_disp.push_str(&format!(") / {} = {:.2}", divide_by, total_score));
+    state.to_copy_val = daily_score_disp.clone();
+    // Create the score report
+    println!("Today's daily score:");
+    println!("{}", daily_score_disp);
+    // Options: copy, continue, restart, edit
+    println!("To copy the report, enter `copy`");
+}
+
+pub fn run_tip(state: &mut remstate::RemState, key: &str, grepval: Option<&str>) {
+    // Search for the given file and display it, so a tip can be found
+    match state.config.get_tip_value(key) {
+        Some(tip_value) => {
+            // Open and load the file, if possible
+            match utils::read_file(&tip_value) {
+                Some(thecontents) => {
+                    // Load the file
+                    state.file_loaded = thecontents.clone();
+                    println!("The file at {} is loaded into the buffer.", tip_value);
+                    match grepval {
+                        // Automatically grep
+                        Some(query) => {
+                            run_grep(state, query);
+                        },
+                        _ => {
+                            println!("Consider using `grep` or `print`");
+                        }
+                    }
+                },
+                _ => {
+                    println!("The file pointed to doesn't exist");
+                }
+            }
+        },
+        _ => {
+            // Failed
+            println!("The tip nickname doesn't exist");
+        }
+    }
+}
+
+pub fn run_grep(state: &mut remstate::RemState, query: &str) {
+    // Search the file for lines including it
+    let mut success: bool = false;
+    println!("Searching...");
+    for (i, line) in state.file_loaded.lines().enumerate() {
+        // Match?
+        if line.to_lowercase().find(&query.to_lowercase()).is_some() {
+            // Found
+            println!("   {:5} {}", i + 1, line);
+            success = true;
+        }
+    }
+    if !success {
+        println!("I found no results in the file.");
+    }
+}

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -68,8 +68,8 @@ pub fn run_tip(state: &mut remstate::RemState, key: &str, grepval: Option<&str>)
     }
 }
 
+// Search the file for lines including the query
 pub fn run_grep(state: &mut remstate::RemState, query: &str) {
-    // Search the file for lines including it
     let mut success: bool = false;
     println!("Searching...");
     for (i, line) in state.file_loaded.lines().enumerate() {
@@ -82,5 +82,185 @@ pub fn run_grep(state: &mut remstate::RemState, query: &str) {
     }
     if !success {
         println!("I found no results in the file.");
+    }
+}
+
+/// Get the line of the given number
+pub fn run_line(state: &mut remstate::RemState, line_num: &str) {
+    match line_num.parse::<usize>() {
+        Ok(linenum) => {
+            if linenum < 1 || linenum > state.file_loaded.lines().count() {
+                println!("Enter a line number from 1 to {}", state.file_loaded.lines().count());
+                return;
+            }
+            // Print the line
+            println!("   {:5} {}", linenum, state.file_loaded.lines().collect::<Vec<&str>>()[linenum - 1]);
+        },
+        _ => {
+            println!("Enter a line number from 1 to {}", state.file_loaded.lines().count());
+        }
+    }
+}
+
+pub fn run_tda(state: &mut remstate::RemState, todo_string: &str) {
+    // Append to the end of todos
+    if utils::append_to_file(&state.config.get_todo_path(), &format!("- {}", todo_string)) {
+        println!("Todo added successfully");
+    } else {
+        println!("Todo could not be added");
+    }
+}
+
+/// Todo top (up until the given number of headers, default 1)
+pub fn run_tdt(state: &mut remstate::RemState, count: u32) {
+    const TDT_MAX_ARG: u32 = 9;
+    if count > TDT_MAX_ARG {
+        println!("It is unreasonable to request this many ({}) todo headers.", count);
+        println!("Please manually open the todo file in a text editor.");
+        println!("To find its path, run 'remfetch' and visit the listed config file.");
+        return;
+    }
+    // Get the end of todos
+    match utils::read_file(&state.config.get_todo_path()) {
+        Some(contents) => {
+            // Print the end of the file up until the first hash symbol
+            let mut res = String::new();
+            let lines = contents.lines().collect::<Vec<&str>>();
+            let mut headers_seen = 0;
+            state.todos_ids.clear();
+            let mut currid = "a".to_string();
+            for i in (0..lines.len()).rev() {
+                let mut final_line = false;
+                if lines[i].starts_with("##") {
+                    headers_seen += 1;
+                    if headers_seen >= count {
+                        final_line = true;
+                    }
+                }
+                // Track this line's ID
+                state.todos_ids.insert(currid.clone(), i + 1);
+                // Line goes above res (because iterating in reverse)
+                res = format!("{:3}{:5} {}\n{}", currid, i + 1, lines[i], res);
+                if final_line {
+                    break;
+                }
+                currid = utils::generate_next_id(currid.clone());
+            }
+            println!("{}", res);
+        },
+        _ => {
+            println!("Todo file could not be accessed");
+        }
+    }
+}
+
+// TODO: remove unnecessary mut for state parameters above if possible
+/// Clear the todo of a certain ID
+pub fn run_tdc(state: &remstate::RemState, id: &str) {
+    let linenum: usize = match state.todos_ids.get(id) {
+        Some(l) => {
+            *l
+        },
+        _ => {
+            println!("ID does not exist");
+            return;
+        }
+    };
+    match utils::read_file(&state.config.get_todo_path()) {
+        Some(contents) => {
+            let mut lines = contents.lines().collect::<Vec<&str>>();
+            // Check bounds
+            if linenum < 1 || linenum > lines.len() {
+                println!("Line number pointed to is out of bounds");
+                return;
+            }
+            let target: String = lines[linenum - 1].to_string();
+            let res: String = utils::strikethrough_text(&target);
+            // Print successful result
+            println!("   {:5} {}", linenum, res);
+            // Update the contents lines
+            lines[linenum - 1] = &res;
+            let mut newcontents = String::new();
+            for line in lines {
+                newcontents.push_str(&format!("{}\n", line));
+            }
+            // Overwrite the file with the new contents
+            utils::write_to_file(&state.config.get_todo_path(), &newcontents);
+        },
+        _ => {
+            println!("Todo file could not be accessed");
+            return;
+        }
+    }
+}
+
+/// Edit the latest todo
+pub fn run_tde(state: &remstate::RemState, new_todo: &str) {
+    if utils::edit_last_line_of_file(&state.config.get_todo_path(), &format!("- {}", new_todo), false) {
+        println!("- {}", new_todo);
+    } else {
+        println!("Topmost todo could not be edited");
+    }
+}
+
+/// Append-edit the latest todo
+pub fn run_tdae(state: &remstate::RemState, new_todo: &str) {
+    let formatted_to_append: String = match new_todo.chars().next().unwrap_or(' ') {
+        ',' | ';' | '-' | '.' => {
+            // Punctuation, so don't include a space between the original and appended contents
+            new_todo.to_string()
+        },
+        _ => {
+            format!(" {}", new_todo)
+        }
+    };
+    if utils::edit_last_line_of_file(&state.config.get_todo_path(), &formatted_to_append, true) {
+        println!("Appended to the topmost todo");
+    } else {
+        println!("Topmost todo could not be edited");
+    }
+}
+
+/// Start a new day as a header in the todo list
+pub fn run_tdn(state: &remstate::RemState) {
+    // Append the day to the end of todos
+    if utils::append_to_file(&state.config.get_todo_path(), &format!("## {}", utils::get_date_only_formatted())) {
+        println!("New day added successfully");
+    } else {
+        println!("Todo could not be added");
+    }
+}
+
+/// Run a shell alias
+pub fn run_al(state: &remstate::RemState, alias: &str) -> command::CommandResult {
+    match state.config.get_shell_alias(&alias) {
+        Some(alias) => {
+            let command_successful = utils::run_command(&alias.command);
+            // Only quit if successful AND desired
+            if command_successful && alias.quit_after_running {
+                command::CommandResult::EndProgram
+            } else {
+                command::CommandResult::Nominal
+            }
+        },
+        _ => {
+            println!("The shell alias doesn't exist");
+            command::CommandResult::Nominal
+        }
+    }
+}
+
+/// Display all aliases
+pub fn run_al_ls(state: &remstate::RemState) {
+    println!("All shell aliases added:");
+    println!("{}", state.config.display_shell_aliases());
+    println!("All rem aliases added:");
+    println!("{}", state.config.display_rem_aliases());
+}
+
+/// Print the current file
+pub fn run_print(state: &remstate::RemState) {
+    for (i, line) in state.file_loaded.lines().enumerate() {
+        println!("   {:5} {}", i + 1, line);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod remfetch;
 mod command;
 mod remstate;
+mod feature;
 
 /* TODO:
     feat: allow intaking a file as an argument, or taking flags?
@@ -23,15 +24,18 @@ mod remstate;
 
 fn main() {
     // Initialize
-    let rem_data = remdata::RemData::new("0.6.0", "2025/02/04", true);
+    let rem_data = remdata::RemData::new("0.6.1", "2025/08/03", true);
     let mut rem = rem::Rem::new(rem_data.clone());
 
     // Begin the input loop immediately
     loop {
         let user_input = utils::get_user_input_line();
-        let should_quit = rem.respond_to_input(user_input, 0);
-        if should_quit {
-            break;
+        let res = rem.respond_to_input(user_input, 0);
+        match res {
+            Some(command::CommandResult::EndProgram) => {
+                break;
+            },
+            _ => ()
         }
     }
     // End

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod utils;
 mod rem;
 mod config;
 mod remfetch;
+mod command;
+mod remstate;
 
 /* TODO:
     feat: allow intaking a file as an argument, or taking flags?

--- a/src/rem.rs
+++ b/src/rem.rs
@@ -1,18 +1,15 @@
 use crate::remdata;
-use crate::utils;
 use crate::config::Config;
-use crate::remfetch;
 use crate::command;
 use crate::remstate;
 use std::collections::hash_map::HashMap;
 
-/// The data and methods for Rem
+/// Stores state and runs commands from user input
 pub struct Rem {
     state: remstate::RemState
 }
 
 impl Rem {
-    /// Create a new Rem
     pub fn new(rem_data: remdata::RemData) -> Rem {
         Rem {
             state: remstate::RemState {
@@ -34,15 +31,13 @@ impl Rem {
             println!("Infinitely recursive command encountered (recursed over {MAX_RECURSION_LEVEL} times)");
             return None
         }
-        // TODO: refactor all into run_command
         let res = command::run_command(&input, &mut self.state);
         if res.is_some() {
             return res;
         }
         // Couldn't run the command verbatim, so check rem aliases
         // TODO: refactor this?
-        let parsed: Vec<String> = Self::parse_input(&input);
-        let first_arg = Self::argument_at_index(&parsed, 0);
+        let first_arg = Self::first_arg(&input);
         match self.state.config.get_rem_alias_value(first_arg) {
             Some(val) => {
                 self.run_rem_alias(&val, recursion_level + 1)
@@ -52,245 +47,10 @@ impl Rem {
                 None
             }
         }
-
-        /*match first_arg {
-            "score" => {
-                // Score
-                self.run_score();
-            },
-            "version" | "ver" => {
-                // Simple version information
-                println!("REMSLICE ({})", self.rem_data.to_string())
-            },
-            "remfetch" => {
-                // Remfetch
-                println!("{}", remfetch::remfetch(&self.rem_data));
-            },
-            "bye" => {
-                // Message and quit
-                println!("bye!");
-                utils::await_enter();
-                return true;
-            },
-            "ping" => {
-                // Ping
-                self.ping_count += 1;
-                println!("pong! (x{})", self.ping_count);
-            },
-            "help" => {
-                // Help
-                self.run_help();
-            },
-            "wipe" => {
-                // Wipe
-                self.run_wipe_screen();
-            },
-            "pwd" if parsed.len() == 1 => {
-                // Print the current working directory
-                println!("{}", utils::get_current_working_dir());
-            },
-            "tip" | "b" if parsed.len() >= 3 => {
-                // Tip and grep
-                self.run_tip(parsed[1].clone(), Some(utils::trailing_portion_of_input(&input, 3).to_lowercase()));
-            },
-            "tip" | "b" if parsed.len() == 2 => {
-                // Tip
-                self.run_tip(parsed[1].clone(), None);
-            },
-            "tip-ls" => {
-                // List all tips and their directories
-                self.run_tip_ls();
-            },
-            "grep" if parsed.len() >= 2 => {
-                // Grep (case-insensitive)
-                self.run_grep(utils::trailing_portion_of_input(&input, 2).to_lowercase());
-            },
-            "line" if parsed.len() >= 2 => {
-                // Print the line number
-                self.run_line(utils::trailing_portion_of_input(&input, 2).to_lowercase());
-            },
-            "tda" if parsed.len() >= 2 => {
-                // Add a todo
-                self.run_tda(utils::trailing_portion_of_input(&input, 2));
-            },
-            "tdt" => {
-                // Display the top of the todo list (1 level)
-                self.run_tdt(1);
-            },
-            "tdt2" => {
-                // Display the top of the todo list (2 levels)
-                self.run_tdt(2);
-            },
-            "tdc" if parsed.len() == 2 => {
-                // Clear a todo based on its ID
-                self.run_tdc(parsed[1].clone());
-            },
-            "tde" if parsed.len() >= 2 => {
-                // Edit the latest todo
-                self.run_tde(utils::trailing_portion_of_input(&input, 2));
-            },
-            "tdae" if parsed.len() >= 2 => {
-                // Append-edit the latest todo
-                self.run_tdae(utils::trailing_portion_of_input(&input, 2));
-            },
-            "tdn" => {
-                // Add a new day to the todo log
-                self.run_tdn();
-            },
-            "al" => {
-                // Run the command represented by an alias
-                if self.run_al(parsed[1].clone()) {
-                    // Should quit
-                    return true;
-                }
-            },
-            "al-ls" => {
-                // List all aliases and their commands
-                self.run_al_ls();
-            }
-            "print" => {
-                // Print the file
-                self.run_print();
-            },
-            "copy" | "y" => {
-                // Try to copy whatever is in the copy val
-            },
-            "paste" | "p" => {
-                // Try to paste whatever is in the clipboard val
-            },
-            "pasterun!" | "pr!" => {
-                // DEPRECATED
-                // Try to run whatever is in the clipboard
-                match utils::paste_from_clipboard() {
-                    Some(contents) => {
-                        println!("Running: `{}`", contents);
-                        if self.respond_to_input(contents, recursion_level + 1) {
-                            // Should quit
-                            return true;
-                        }
-                    },
-                    _ => {
-                        println!("Couldn't paste the clipboard contents");
-                    }
-                }
-            },
-            "exit" | "quit" | "q" => {
-                // Exit immediately
-                // TODO: allow other return types (enum for this function's return)
-                return true;
-            },
-            "time" => {
-                // Get the current time
-                let output = utils::get_time_formatted();
-                self.state.to_copy_val = output.clone();
-                println!("{}", output);
-            },
-            _ => {
-                // No match out of existing commands
-                // Check all rem aliases
-                match self.state.config.get_rem_alias_value(first_arg) {
-                    Some(val) => {
-                        // Execute the current rem alias
-                        if self.run_rem_alias(&val, recursion_level + 1) {
-                            // Should quit
-                            return true;
-                        }
-                    }
-                    _ => {
-                        println!("?");
-                    }
-                }
-            }
-        }
-        false*/
     }
 
-    /// Run action: help
-    fn run_help(&mut self) {
-        println!("A detailed list of all commands can be found in `README.md`;");
-        println!("please check it out for the features and cool stuff!");
-        println!("- `exit`/`quit`/`q` - exit immediately");
-        println!("- `version`/`ver` - display simple version information");
-    }
-
-    /// Run action: score calculation
-    fn run_score(&mut self) {
-        // Get based on config
-        let divide_by: f32 = self.state.config.score_divby();
-        let formula_number: &str = &self.state.config.score_formula_number();
-        // Obtain relevant information
-        println!("Today's questions:");
-        let mut daily_score_disp = format!("Daily Score (Formula {}) = (", formula_number);
-        let mut total_score: f32 = 0.0;
-        for cat in self.state.config.score_positive() {
-            println!("{}", cat);
-            let uin = utils::get_user_input_decimal(0.0, 1.0);
-            total_score += uin;
-            daily_score_disp.push_str(&format!(" + {:.2}", uin));
-        }
-        for cat in self.state.config.score_negative() {
-            println!("{}", cat);
-            let uin = utils::get_user_input_decimal(0.0, 1.0);
-            total_score -= uin;
-            daily_score_disp.push_str(&format!(" - {:.2}", uin));
-        }
-        // Calculate and format
-        total_score /= divide_by;
-        daily_score_disp.push_str(&format!(") / {} = {:.2}", divide_by, total_score));
-        self.state.to_copy_val = daily_score_disp.clone();
-        // Create the score report
-        println!("Today's daily score:");
-        println!("{}", daily_score_disp);
-        // Options: copy, continue, restart, edit
-        println!("To copy the report, enter `copy`");
-    }
-
-    /// Run action: wipe the screen
-    fn run_wipe_screen(&self) {
-        // Print enough times that the screen gets filled
-        for _i in 0..100 {
-            println!();
-        }
-        println!("The screen is clear!");
-    }
-
-    /// Run action: grep
-    fn run_grep(&mut self, query: String) {
-        // Search the file for lines including it
-        let mut success: bool = false;
-        println!("Searching...");
-        for (i, line) in self.state.file_loaded.lines().enumerate() {
-            // Match?
-            if line.to_lowercase().find(&query).is_some() {
-                // Found
-                println!("   {:5} {}", i + 1, line);
-                success = true;
-            }
-        }
-        if !success {
-            println!("I found no results in the file.");
-        }
-    }
-
-    /// Get the argument at an index of the input
-    fn argument_at_index(parsed: &Vec<String>, i: usize) -> &str {
-        if i >= parsed.len() {
-            ""
-        } else {
-            &parsed[i]
-        }
-    }
-
-    /// Parse the input
-    fn parse_input(input: &str) -> Vec<String> {
-        // Split by spaces, strip, remove unnecessary characters
-        // TODO: impl myself to ignore spaces and keep case within quotes, handle backslashes, etc.
-        let splitted: Vec<&str> = input.split(' ').collect::<Vec<&str>>();
-        let mut res: Vec<String> = Vec::new();
-        for arg in splitted {
-            res.push(arg.trim().to_lowercase().to_string());
-        }
-        res
+    fn first_arg(input: &str) -> &str {
+        input.splitn(2, ' ').collect::<Vec<&str>>()[0]
     }
 
     /// Run a rem alias, returning whether to quit

--- a/src/remstate.rs
+++ b/src/remstate.rs
@@ -1,0 +1,13 @@
+use crate::remdata;
+use crate::config::Config;
+use std::collections::hash_map::HashMap;
+
+pub struct RemState {
+    pub rem_data: remdata::RemData,
+    pub ping_count: u32,
+    pub to_copy_val: String,
+    pub file_loaded: String,
+    /// Store the ID (string of lowercase letters) and corresponding line NUMBER (not index)
+    pub todos_ids: HashMap<String, usize>,
+    pub config: Config
+}


### PR DESCRIPTION
Heavily refactored the way commands are stored and processed. The majority of functionality should not change as a result
## Code changes
- Refactored rem state into its own struct
- Refactored commands into a dedicated `command.rs` file. They now store their name, structure, and functionality more idiomatically
- All commands are constructed in a vec in the file, and some of them reference larger functions in the `feature.rs` file. To change a command, the only files that should be changed are `command.rs` and `feature.rs`
- Commands now return the `CommandResult` enum rather than a boolean to indicate whether the program should quit
## Features/fixes
- Added the `tdt {n}` command, which lists the top n todo headers (to a reasonable degree)
- Added `clear` as another alias of `wipe`