### PR TITLE
Timed todos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "remslice"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "cli-clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remslice"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ rem_alias h al ffc
 - `tip-ls` - list all available tips and their file paths
 - `grep` - search through the currently loaded file for lines containing a specific term (case-insensitive; instantly displays)
 - `line {line number}` - print the given line of the currently loaded file
+- `al {shell alias}` - run the command defined by a certain shell alias in the config file
+- `al-ls` - list all available shell and rem aliases and what they refer to
+### Todos
 - `tda` - "todo append": add an entry into the todo file specified in `remrc.txt` (entries are automatically markdown bulleted with a dash)
 - `tdt` - "todo top": display the top (most recent) entries in the todo file (up until the most recent `##` header); display lowercase alphabetical IDs alongside each entry
 - `tdt2` - "todo top x2": display more of the top todo entries (up until the 2nd most recent `##` header)
@@ -154,9 +157,8 @@ rem_alias h al ffc
 - `tde` - "todo edit": edit the topmost todo entry by replacing it, used for making a correction
 - `ted` - "todo editor": launch a text editor for doing more complex reorganization of your todos
 - `tdae` - "todo append-edit": append text to the topmost todo entry, used for making a correction
+- `tdat` - "todo append-time": add a todo entry prefaced by the current time
 - `tdn` - "todo new day": insert the current date as a new `##` header in the todo file
-- `al {shell alias}` - run the command defined by a certain shell alias in the config file
-- `al-ls` - list all available shell and rem aliases and what they refer to
 
 ## More
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -73,13 +73,9 @@ impl Command {
 pub fn run_command(
     full_input: &str,
     state: &mut remstate::RemState,
-    command_list: &Vec<Command>
+    command_list: &[Command]
 ) -> Option<CommandResult> {
-    let processed = utils::process_input(&full_input);
-    if processed.is_none() {
-        return None;
-    }
-    let (num_args, command_name) = processed.unwrap();
+    let (num_args, command_name) = utils::process_input(full_input)?;
     let found = command_list.iter().find(|&x| x.matches(&command_name, num_args));
     match found {
         Some(command) => {

--- a/src/command_lists/rem_commands.rs
+++ b/src/command_lists/rem_commands.rs
@@ -16,7 +16,7 @@ pub static REM_COMMANDS: LazyLock<Vec<Command>> = LazyLock::new(|| {vec![
     Command::new(
         utils::string_vec!["version", "ver"], ArgsLim::None,
         |_args, state| {
-            println!("REMSLICE ({})", state.rem_data.to_string());
+            println!("REMSLICE ({})", state.rem_data);
             CommandResult::Nominal
         }
     ),

--- a/src/command_lists/rem_commands.rs
+++ b/src/command_lists/rem_commands.rs
@@ -178,6 +178,12 @@ pub static REM_COMMANDS: LazyLock<Vec<Command>> = LazyLock::new(|| {vec![
         }
     ),
     Command::new(
+        utils::string_vec!["tdat"], ArgsLim::EndlessLastArg(1),
+        |args, state| {
+            feature::run_tdat(state, &args[0])
+        }
+    ),
+    Command::new(
         utils::string_vec!["tdn"], ArgsLim::None,
         |_args, state| {
             feature::run_tdn(state)
@@ -243,7 +249,7 @@ pub static REM_COMMANDS: LazyLock<Vec<Command>> = LazyLock::new(|| {vec![
     Command::new(
         utils::string_vec!["time"], ArgsLim::None,
         |_args, state| {
-            let output = utils::get_time_formatted();
+            let output = utils::get_date_time_formatted();
             state.to_copy_val = output.clone();
             println!("{}", output);
             CommandResult::Nominal

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,12 +72,8 @@ impl Config {
 
     /// Get the value of a tip starting with a key
     pub fn get_tip_value(&self, start: &str) -> Option<String> {
-        for tip in &self.tips {
-            if tip.key.starts_with(start) {
-                return Some(tip.value.clone());
-            }
-        }
-        return None;
+        self.tips.iter().find(|tip| tip.key.starts_with(start))
+            .map(|tip| tip.value.clone())
     }
 
     /// Display all tips
@@ -86,27 +82,18 @@ impl Config {
         for tip in &self.tips {
             res.push_str(&format!("   {} : {}\n", tip.key, tip.value));
         }
-        return res;
+        res
     }
 
     /// Get the information about a shell alias matching a key
     pub fn get_shell_alias(&self, search_for: &str) -> Option<ShellAlias> {
-        for alias in &self.shell_aliases {
-            if alias.key == search_for {
-                return Some(alias.clone());
-            }
-        }
-        return None;
+        self.shell_aliases.iter().find(|alias| alias.key == search_for).cloned()
     }
 
     /// Get the value of a rem alias matching a key
     pub fn get_rem_alias_value(&self, search_for: &str) -> Option<String> {
-        for alias in &self.rem_aliases {
-            if alias.key == search_for {
-                return Some(alias.value.clone());
-            }
-        }
-        return None;
+        self.rem_aliases.iter().find(|alias| alias.key == search_for)
+            .map(|alias| alias.value.clone())
     }
 
     /// Display all shell aliases
@@ -120,7 +107,7 @@ impl Config {
                 alias.command
             ));
         }
-        return res;
+        res
     }
 
     /// Display all rem aliases
@@ -129,7 +116,7 @@ impl Config {
         for alias in &self.rem_aliases {
             res.push_str(&format!("   {} : {}\n", alias.key, alias.value));
         }
-        return res;
+        res
     }
 
     /// Get all positive score categories

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -90,8 +90,8 @@ pub fn run_line(state: &remstate::RemState, line_num: &str) -> CommandResult {
     }
 }
 
+/// Append to the end of todos
 pub fn run_tda(state: &remstate::RemState, todo_string: &str) -> CommandResult {
-    // Append to the end of todos
     if utils::append_to_file(&state.config.todo_path, &format!("- {}", todo_string)) {
         println!("Todo added successfully");
         CommandResult::Nominal
@@ -204,6 +204,11 @@ pub fn run_tdae(state: &remstate::RemState, new_todo: &str) -> CommandResult {
     } else {
         CommandResult::Error("Topmost todo could not be edited".to_string())
     }
+}
+
+/// Append to the end of todos, prefaced by the time
+pub fn run_tdat(state: &remstate::RemState, todo_string: &str) -> CommandResult {
+    run_tda(state, &format!("{} {}", utils::get_time_formatted(), todo_string))
 }
 
 /// Start a new day as a header in the todo list

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -62,7 +62,7 @@ pub fn run_grep(state: &remstate::RemState, query: &str) {
     println!("Searching...");
     for (i, line) in state.file_loaded.lines().enumerate() {
         // Match?
-        if line.to_lowercase().find(&query.to_lowercase()).is_some() {
+        if line.to_lowercase().contains(&query.to_lowercase()) {
             // Found
             println!("   {:5} {}", i + 1, line);
             success = true;
@@ -231,7 +231,7 @@ pub fn run_ted(state: &remstate::RemState) -> CommandResult {
 
 /// Run a shell alias
 pub fn run_al(state: &remstate::RemState, alias: &str) -> CommandResult {
-    match state.config.get_shell_alias(&alias) {
+    match state.config.get_shell_alias(alias) {
         Some(alias) => {
             let command_successful = utils::run_shell_command(&alias.command);
             // Only quit if successful AND desired

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,8 @@ fn main() {
     loop {
         let user_input = utils::get_user_input_line();
         let res = rem.respond_to_input(user_input, 0);
-        match res {
-            Some(command::CommandResult::EndProgram) => {
-                break;
-            },
-            _ => ()
+        if let Some(command::CommandResult::EndProgram) = res {
+            break;
         }
     }
     // End

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
     // Initialize
-    let rem_data = remdata::RemData::new(VERSION, "2025/08/08", true);
+    let rem_data = remdata::RemData::new(VERSION, "2026/02/20", true);
     let mut rem = rem::Rem::new(rem_data.clone());
 
     // Begin the input loop immediately

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,11 @@ mod command_lists;
     test installing and copying on linux
 */
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn main() {
     // Initialize
-    let rem_data = remdata::RemData::new("0.6.2", "2025/08/08", true);
+    let rem_data = remdata::RemData::new(VERSION, "2025/08/08", true);
     let mut rem = rem::Rem::new(rem_data.clone());
 
     // Begin the input loop immediately
@@ -36,5 +38,4 @@ fn main() {
             break;
         }
     }
-    // End
 }

--- a/src/remdata.rs
+++ b/src/remdata.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// Stores the REM data
 pub struct RemData {
     recent_version: String,
@@ -13,16 +15,6 @@ impl RemData {
             edit_date: edit_date.to_string(),
             morning
         }
-    }
-
-    /// Represent the Data as a one-line string
-    pub fn to_string(&self) -> String {
-        format!(
-            "R: v{}, E: {}, M: {}",
-            self.recent_version,
-            self.edit_date,
-            if self.morning { "[success]" } else { "[failure]" }
-        )
     }
 
     /// Clone
@@ -47,5 +39,17 @@ impl RemData {
     /// Get the morning value
     pub fn get_m(&self) -> bool {
         self.morning
+    }
+}
+
+impl fmt::Display for RemData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "R: v{}, E: {}, M: {}",
+            self.recent_version,
+            self.edit_date,
+            if self.morning { "[success]" } else { "[failure]" }
+        )
     }
 }

--- a/src/remfetch.rs
+++ b/src/remfetch.rs
@@ -7,20 +7,20 @@ pub fn remfetch(current_remdata: &remdata::RemData) -> String {
     // Like neofetch/fastfetch, but for remslice
     // Meant to look like an orange slice
     let current_morning = if current_remdata.get_m() { "[success]" } else { "[failure]" };
-    res.push_str(&format!("                          ,.           REMSLICE\n"));
-    res.push_str(&format!("                        == =-\\         --------\n"));
+    res.push_str("                          ,.           REMSLICE\n");
+    res.push_str("                        == =-\\         --------\n");
     res.push_str(&format!("                      ==.  O  \\        REM/Recent Version: {}\n", current_remdata.get_r()));
     res.push_str(&format!("                    ==   O_____|       REM/Edit Date:      {}\n", current_remdata.get_e()));
     res.push_str(&format!("                  ==  ____   O |       REM/Morning:        {}\n", current_morning));
     res.push_str(&format!("                ==____        =        Current Time:       {}\n", utils::get_time_formatted()));
     res.push_str(&format!("              ==]_  O  . .   /         OS:                 {}\n", utils::get_os()));
     res.push_str(&format!("            == | ] .        =          Config Path:        {}\n", utils::get_config_path()));
-    res.push_str(&format!("          ==  |    ]  O   O/           \n"));
-    res.push_str(&format!("        ==    | O    ]    =            \n"));
-    res.push_str(&format!("      ==  .  |    .   ]==-             \n"));
-    res.push_str(&format!("    /=      |  .O   ==-                \n"));
-    res.push_str(&format!("     -===  |  =====-                   \n"));
-    res.push_str(&format!("         -===-                         \n"));
-    res.push_str(&format!("                                       \n"));
+    res.push_str("          ==  |    ]  O   O/           \n");
+    res.push_str("        ==    | O    ]    =            \n");
+    res.push_str("      ==  .  |    .   ]==-             \n");
+    res.push_str("    /=      |  .O   ==-                \n");
+    res.push_str("     -===  |  =====-                   \n");
+    res.push_str("         -===-                         \n");
+    res.push_str("                                       \n");
     res
 }

--- a/src/remfetch.rs
+++ b/src/remfetch.rs
@@ -12,7 +12,7 @@ pub fn remfetch(current_remdata: &remdata::RemData) -> String {
     res.push_str(&format!("                      ==.  O  \\        REM/Recent Version: {}\n", current_remdata.get_r()));
     res.push_str(&format!("                    ==   O_____|       REM/Edit Date:      {}\n", current_remdata.get_e()));
     res.push_str(&format!("                  ==  ____   O |       REM/Morning:        {}\n", current_morning));
-    res.push_str(&format!("                ==____        =        Current Time:       {}\n", utils::get_time_formatted()));
+    res.push_str(&format!("                ==____        =        Current Time:       {}\n", utils::get_date_time_formatted()));
     res.push_str(&format!("              ==]_  O  . .   /         OS:                 {}\n", utils::get_os()));
     res.push_str(&format!("            == | ] .        =          Config Path:        {}\n", utils::get_config_path()));
     res.push_str("          ==  |    ]  O   O/           \n");

--- a/src/remstate.rs
+++ b/src/remstate.rs
@@ -27,7 +27,7 @@ impl RemState {
                     if Self::is_empty_or_comment(line) {
                         continue;
                     }
-                    let res = command::run_command(&line, self, command_lists::get_config_commands());
+                    let res = command::run_command(line, self, command_lists::get_config_commands());
                     match res {
                         Some(command::CommandResult::Error(descr)) => {
                             println!("Configuration error in .remrc: {}", descr);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -135,16 +135,19 @@ fn get_time() -> chrono::DateTime<chrono::Local> {
     chrono::Local::now()
 }
 
-/// Get the current local time, formatted
+/// Get the current local date and time, formatted (e.g. 2020/01/01 20:05)
+pub fn get_date_time_formatted() -> String {
+    get_time().format("%Y/%m/%d %H:%M").to_string()
+}
+
+/// Get the current local time, formatted (e.g. 20:05)
 pub fn get_time_formatted() -> String {
-    let thetime = get_time();
-    thetime.format("%Y/%m/%d %H:%M").to_string()
+    get_time().format("%H:%M").to_string()
 }
 
 /// Get the current date only, formatted
 pub fn get_date_only_formatted() -> String {
-    let thetime = get_time();
-    thetime.format("%Y/%m/%d").to_string()
+    get_time().format("%Y/%m/%d").to_string()
 }
 
 /// Get the current operating system

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,10 +6,6 @@ use std::fs;
 use std::env::consts::OS;
 use std::process::Command;
 
-// Keep the line ending '\n' for consistency in editing files
-#[allow(dead_code)]
-const LINE_ENDING: &'static str = "\n";
-
 /// Get the user's input
 pub fn get_user_input_line() -> String {
     print!("> ");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,10 +6,6 @@ use std::fs;
 use std::env::consts::OS;
 use std::process::Command;
 
-use cli_clipboard;
-use chrono;
-use home;
-
 // Keep the line ending '\n' for consistency in editing files
 #[allow(dead_code)]
 const LINE_ENDING: &'static str = "\n";
@@ -68,49 +64,22 @@ pub fn get_current_working_dir() -> String {
 
 /// Copy a string to the clipboard
 pub fn copy_to_clipboard(s: &str) -> bool {
-    match cli_clipboard::set_contents(s.to_owned()) {
-        Ok(_) => {
-            // Success
-            true
-        },
-        Err(_err) => {
-            // Failure
-            // TODO: handle?
-            false
-        }
-    }
+    cli_clipboard::set_contents(s.to_owned()).is_ok()
 }
 
 /// Get a string from the clipboard
 pub fn paste_from_clipboard() -> Option<String> {
-    match cli_clipboard::get_contents() {
-        Ok(contents) => {
-            // Success
-            Some(contents)
-        },
-        Err(_err) => {
-            // Failure
-            // TODO: handle?
-            None
-        }
-    }
+    cli_clipboard::get_contents().ok()
 }
 
 /// Get the contents of a file given its path, if possible
 pub fn read_file(path: &str) -> Option<String> {
-    match fs::read_to_string(path) {
-        Ok(thepath) => {
-            Some(thepath)
-        },
-        _ => {
-            None
-        }
-    }
+    fs::read_to_string(path).ok()
 }
 
 /// Append to a file given its path, if possible, and return whether successful
 pub fn append_to_file(path: &str, to_write: &str) -> bool {
-    let file =  fs::OpenOptions::new().write(true).append(true).open(path);
+    let file =  fs::OpenOptions::new().append(true).open(path);
     match file {
         Ok(mut fileval) => {
             // Append the new line
@@ -162,14 +131,7 @@ pub fn edit_last_line_of_file(path: &str, new_last_line: &str, append: bool) -> 
 
 /// Write to a file given its path, if possible, and return whether successful
 pub fn write_to_file(path: &str, to_write: &str) -> bool {
-    match fs::write(path, to_write) {
-        Ok(_theres) => {
-            true
-        },
-        _ => {
-            false
-        }
-    }
+    fs::write(path, to_write).is_ok()
 }
 
 /// Get the current local time
@@ -273,7 +235,7 @@ pub fn process_input(full_input: &str) -> Option<(i32, String)> {
     // TODO: impl ignoring spaces and keeping case within quotes, handling backslashes, etc.
     let splitted: Vec<&str> = full_input.split(' ').collect::<Vec<&str>>();
     match splitted.len() {
-        0 => return None,
+        0 => None,
         _ => Some(((splitted.len() as i32) - 1, splitted[0].to_string()))
     }
 }
@@ -303,10 +265,8 @@ pub fn strikethrough_text(target: &str) -> String {
             if chars_after_first_dash == 2 {
                 res.push_str("~~");
             }
-            if c == '-' {
-                if chars_after_first_dash == -1 {
-                    chars_after_first_dash = 0;
-                }
+            if c == '-' && chars_after_first_dash == -1 {
+                chars_after_first_dash = 0;
             }
             if chars_after_first_dash != -1 {
                 chars_after_first_dash += 1;


### PR DESCRIPTION
Added the "todo add timed" feature, which prefaces entries by their time of addition (e.g. running `tdat this is a test` at 8:05pm will add the todo `- 20:05 this is a test`).

Also made some small code improvements and complied with default `clippy` lints.